### PR TITLE
スムーススクロールを廃止

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -82,7 +82,6 @@ useSchemaOrg([
 </script>
 
 <template>
-  <Html class="scroll-smooth" />
   <Body class="bg-white text-gray-700" />
   <AppProvider>
     <TheHeader />


### PR DESCRIPTION
わりと邪魔だし、わりとすぐおバグりになるので、廃止。