### PR TITLE
ci: publish workflowのtriggerなど変更

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,50 +4,59 @@ name: Publish
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events
+  # Triggers the workflow on push event, but only for main branch
   push:
-  pull_request:
+    branches:
+      - main
+  # Triggers the workflow on pull request event, but only for pull request to main branch
+  # pull_request is not allowed to use secrets, so we use pull_request_target instead
+  pull_request_target:
+    branches:
+      - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  # default contents: read & write (in forked repos, only read)
+  contents: read
+  # default deployments: read & write (in forked repos, only read)
+  deployments: write
+  # default pull-requests: read & write (in forked repos, only read)
+  pull-requests: write
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-
   # Deploy
   deploy:
     name: Deploy
-    if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [ubuntu-latest]
         node: [18]
+    # Cancel previous runs that are not completed yet
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: Get cache directory
-        id: npm-cache-directory
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      - name: Cache
-        id: npm-cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.npm-cache-directory.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
+
       - name: Install dependencies
         run: npm ci
+
       - name: Run generate
         run: npm run generate
+
       - name: Publish to Cloudflare Pages
         id: cloudflare-pages-deploy
         uses: cloudflare/pages-action@v1
@@ -57,27 +66,29 @@ jobs:
           projectName: jaoweb
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create commit comment
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/commit-comment@v2
         with:
           body: |
             ### ⚡ Successfully Cloudflare Pages deployed!
-            |Name|Link|
-            |:---|:---|
-            |<span aria-hidden="true">🔨</span> Latest commit| ${{ github.sha }} |
-            |<span aria-hidden="true">🔍</span> Latest deploy log| ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
-            |<span aria-hidden="true">😎</span> Deploy Preview Url | [${{ steps.cloudflare-pages-deploy.outputs.url }}](${{ steps.cloudflare-pages-deploy.outputs.url }}) |
-            |<span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare-pages-deploy.outputs.environment }} |
+            | Name | Link |
+            | :--- | :--- |
+            | <span aria-hidden="true">🔨</span> Latest commit | ${{ github.sha }} |
+            | <span aria-hidden="true">🔍</span> Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
+            | <span aria-hidden="true">😎</span> Deploy Preview Url | [${{ steps.cloudflare-pages-deploy.outputs.url }}](${{ steps.cloudflare-pages-deploy.outputs.url }}) |
+            | <span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare-pages-deploy.outputs.environment }} |
+
       - name: Create PR comment
         if: ${{ github.event_name != 'push' }}
         uses: mshick/add-pr-comment@v2
         with:
           message: |
             ### ⚡ Successfully Cloudflare Pages deployed!
-            |Name|Link|
-            |:---|:---|
-            |<span aria-hidden="true">🔨</span> Latest commit| ${{ github.sha }} |
-            |<span aria-hidden="true">🔍</span> Latest deploy log| ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
-            |<span aria-hidden="true">😎</span> Deploy Preview Url | [${{ steps.cloudflare-pages-deploy.outputs.url }}](${{ steps.cloudflare-pages-deploy.outputs.url }}) |
-            |<span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare-pages-deploy.outputs.environment }} |
+            | Name | Link |
+            | :--- | :--- |
+            | <span aria-hidden="true">🔨</span> Latest commit | ${{ github.sha }} |
+            | <span aria-hidden="true">🔍</span> Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
+            | <span aria-hidden="true">😎</span> Deploy Preview Url | [${{ steps.cloudflare-pages-deploy.outputs.url }}](${{ steps.cloudflare-pages-deploy.outputs.url }}) |
+            | <span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare-pages-deploy.outputs.environment }} |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ on:
   pull_request_target:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -44,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
`Publish` workflow について、以下の変更を加えました。

## トリガーイベントについて

トリガーとするイベントについて、以下のように変更しました。

- `push`: ブッシュイベントについては main ブランチのみで動作するようにしました
- `pull_request_target`: `pull_request` だと Fork 先から発行された PR で Fork 元オリジナルリポジトリの Secret が読めないため、`pull_request_target` に変更し、main ブランチに対する PR のみ対象とするようにしました。`pull_request_target` については [公式記事「ワークフローをトリガーするイベント」](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#pull_request_target) を参照。

## 権限設定について

権限設定を更新しました。  
`write-all` は危険なので、ワークフロー内の全ジョブに対して `contents: read`, `deployments: write`, `pull-requests: write` の設定をしました。

参照:

- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
- [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## ジョブの実行条件について

`deploy` ジョブの `if` 条件を削除しました。この書き方では `workflow_dispatch` を実行しても動作しない他、`pull_request_target` をトリガーとしたことで Secret にアクセスできるようになったため、Fork からの PR でも動作して構わないためです。(参照: [`ci: forkからのprで実行されないよう変更` in #76](https://github.com/jaoafa/jaoweb4/pull/76/commits/976cf547d7a0266bceea4ec55ba5e863188f7508))

`concurrency` を追加し、同一ワークフロー & ブランチのワークフローが進行している場合、既存のワークフローをキャンセルするようにしました。  
これにより既存ワークフローの処理に時間が掛かっている際に新規にコミットがなされても、古いデプロイがなされなくなります。

## ジョブステップについて

- キャッシュについての処理を改善しました。`actions/setup-node@v3` にはキャッシュ処理がオプションで実装されているため、これを利用します。
  - 参照: [`0. Caching dependencies` in actions/setup-node](https://github.com/actions/setup-node/blob/main/docs/adrs/0000-caching-dependencies.md)
- 読みにくく感じたので、ステップ間に改行を追加しました。
- テーブルの各行に空白を入れるか入れないかが混在していたので、入れるように変更しました（レンダリング後の見た目に変更はありません）。
