### PR TITLE
ci: プルリクエストの場合に複数起動すると既存のジョブが取り消しされてしまう問題修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
         node: [18]
     # Cancel previous runs that are not completed yet
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
       cancel-in-progress: true
     timeout-minutes: 10
 


### PR DESCRIPTION
表題の通り。

`pull_request_target` だと `github.ref` が `refs/heads/main` になるらしく、他のPRとダブってキャンセルされてしまうようです。これを修正しています。