### PR TITLE
ci: Publish workflow の修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -99,27 +99,27 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create commit comment
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
         uses: peter-evans/commit-comment@v2
         with:
           body: |
             ### ⚡ Successfully Cloudflare Pages deployed!
             | Name | Link |
             | :--- | :--- |
-            | <span aria-hidden="true">🔨</span> Latest commit | ${{ github.sha }} |
+            | <span aria-hidden="true">🔨</span> Latest commit | ${{ github.event.pull_request.head.sha || github.sha }} |
             | <span aria-hidden="true">🔍</span> Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
             | <span aria-hidden="true">😎</span> Deploy Preview Url | [${{ steps.cloudflare-pages-deploy.outputs.url }}](${{ steps.cloudflare-pages-deploy.outputs.url }}) |
             | <span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare-pages-deploy.outputs.environment }} |
 
       - name: Create PR comment
-        if: ${{ github.event_name != 'push' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         uses: mshick/add-pr-comment@v2
         with:
           message: |
             ### ⚡ Successfully Cloudflare Pages deployed!
             | Name | Link |
             | :--- | :--- |
-            | <span aria-hidden="true">🔨</span> Latest commit | ${{ github.sha }} |
+            | <span aria-hidden="true">🔨</span> Latest commit | ${{ github.event.pull_request.head.sha || github.sha }} |
             | <span aria-hidden="true">🔍</span> Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
             | <span aria-hidden="true">😎</span> Deploy Preview Url | [${{ steps.cloudflare-pages-deploy.outputs.url }}](${{ steps.cloudflare-pages-deploy.outputs.url }}) |
             | <span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare-pages-deploy.outputs.environment }} |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create commit comment
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/commit-comment@v2
         with:
           body: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
         node: [18]
     # Cancel previous runs that are not completed yet
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
       cancel-in-progress: true
     timeout-minutes: 10
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
次の修正を実施

- [`production` デプロイであるべき場合](https://github.com/jaoafa/jaoweb4/commit/c4f139dd92235f5ffcbd5d13ad134192afe8b37b#commitcomment-106541898)にて、`preview` が割り当てられてしまう問題の暫定修正
  - `github.ref` をチェックアウトすることで [wrangler@2 内で呼び出される](https://github.com/cloudflare/workers-sdk/blob/0a77990457652af36c60c52bf9c38c3a69945de4/packages/wrangler/src/pages/publish.tsx#L219) `git rev-parse --abbrev-ref HEAD` の結果が `main` になることを期待する
- `concurrency.group` の指定が正しくなく、別PRでのプレビューを取り消してしまう問題の修正  
  (see #80)
- #74 など、過去の Git log を使う機能のために checkout 時に `fetch-depth: 0` で全部のコミットログを落とすように
- `workflow_dispatch` の場合にコミットや PR にコメントしないように修正