### PR TITLE
feat: content-listのfilter有効無効をuserとtagで別々にする

### DIFF
--- a/src/components/content/ContentList.vue
+++ b/src/components/content/ContentList.vue
@@ -65,13 +65,15 @@ const filteredData = computed(
 
 <template>
   <div class="not-prose my-10 grid gap-6 md:my-12">
-    <ContentListHeader
-      v-model:author="selectedAuthor"
-      v-model:tag="selectedTag"
-      :enable-author="props.filterUser"
-      :enable-tag="props.filterTag"
-      :content="data || undefined"
-    />
+    <template v-if="props.filterUser || props.filterTag">
+      <ContentListHeader
+        v-model:author="selectedAuthor"
+        v-model:tag="selectedTag"
+        :enable-author="props.filterUser"
+        :enable-tag="props.filterTag"
+        :content="data || undefined"
+      />
+    </template>
 
     <template v-if="filteredData?.length">
       <ul class="grid grid-cols-fill-56 gap-6">

--- a/src/components/content/ContentList.vue
+++ b/src/components/content/ContentList.vue
@@ -5,11 +5,13 @@ import { FaceFrownIcon } from '@heroicons/vue/24/outline'
 const props = withDefaults(
   defineProps<{
     query: string[]
-    filter?: boolean
+    filterUser?: boolean
+    filterTag?: boolean
     limit?: number
   }>(),
   {
-    filter: false,
+    filterUser: false,
+    filterTag: false,
     limit: undefined,
   }
 )
@@ -63,13 +65,13 @@ const filteredData = computed(
 
 <template>
   <div class="not-prose grid gap-6">
-    <template v-if="props.filter">
-      <ContentListHeader
-        v-model:author="selectedAuthor"
-        v-model:tag="selectedTag"
-        :content="data || undefined"
-      />
-    </template>
+    <ContentListHeader
+      v-model:author="selectedAuthor"
+      v-model:tag="selectedTag"
+      :enable-author="props.filterUser"
+      :enable-tag="props.filterTag"
+      :content="data || undefined"
+    />
 
     <template v-if="filteredData?.length">
       <ul class="grid grid-cols-fill-56 gap-6">

--- a/src/components/content/ContentListHeader.vue
+++ b/src/components/content/ContentListHeader.vue
@@ -16,9 +16,17 @@ interface Article extends MarkdownParsedContent {
   }[]
 }
 const props = withDefaults(
-  defineProps<{ content?: Article[]; author?: string; tag?: string }>(),
+  defineProps<{
+    content?: Article[]
+    enableAuthor?: boolean
+    enableTag?: boolean
+    author?: string
+    tag?: string
+  }>(),
   {
     content: () => [],
+    enableAuthor: false,
+    enableTag: false,
     author: '全て',
     tag: '全て',
   }
@@ -62,7 +70,7 @@ const modelTag = computed({
 
 <template>
   <div class="flex flex-wrap items-center gap-3">
-    <Listbox v-model="modelAuthor">
+    <Listbox v-if="enableAuthor" v-model="modelAuthor">
       <div class="relative w-40">
         <ListboxButton
           class="relative w-full rounded-2xl border border-gray-200 bg-gray-50 py-1 pl-3 pr-10 text-xs hover:bg-gray-100 focus:outline-none focus-visible:bg-gray-100"
@@ -123,7 +131,7 @@ const modelTag = computed({
       </div>
     </Listbox>
 
-    <Listbox v-model="modelTag">
+    <Listbox v-if="enableTag" v-model="modelTag">
       <div class="relative z-10 w-40">
         <ListboxButton
           class="relative w-full rounded-2xl border border-gray-200 bg-gray-50 py-1 pl-3 pr-10 text-xs hover:bg-gray-100 focus:outline-none focus-visible:bg-gray-100"

--- a/src/content/2.docs/1.rules/index.md
+++ b/src/content/2.docs/1.rules/index.md
@@ -3,4 +3,4 @@ title: ルール
 layout: list
 ---
 
-:content-list{:query='["docs", "rules"]' :filter-tag='true'}
+:content-list{:query='["docs", "rules"]'}

--- a/src/content/2.docs/1.rules/index.md
+++ b/src/content/2.docs/1.rules/index.md
@@ -3,4 +3,4 @@ title: ルール
 layout: list
 ---
 
-:content-list{:query='["docs", "rules"]'}
+:content-list{:query='["docs", "rules"]' :filter-tag='true'}

--- a/src/content/2.docs/2.policies/index.md
+++ b/src/content/2.docs/2.policies/index.md
@@ -3,4 +3,4 @@ title: 運営方針
 layout: list
 ---
 
-:content-list{:query='["docs", "policies"]'}
+:content-list{:query='["docs", "policies"]' :filter-tag='true'}

--- a/src/content/3.community/1.blog/index.md
+++ b/src/content/3.community/1.blog/index.md
@@ -3,4 +3,4 @@ title: ブログ
 layout: list
 ---
 
-:content-list{:query='["community", "blog"]' :filter='true'}
+:content-list{:query='["community", "blog"]' :filter-user='true' :filter-tag='true'}


### PR DESCRIPTION
表題の通りです。

- see: https://github.com/jaoafa/jaoweb4/pull/67#discussion_r1152757844

ContentList について、ブログ記事一覧以外の利用用途のため、対象とするフィルタを user と tag で別々のフラグとしそれぞれに対して有効無効を指定できるようにしました。

| 両方有効<br>:filter-user='true' :filter-tag='true' | タグフィルタだけ有効<br>:filter-tag='true' | ユーザフィルタだけ有効<br>:filter-user='true' |
|:-:|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/8929706/228743732-d3fa8e6e-d47d-41d5-b2a7-e0ed17036284.png) | ![image](https://user-images.githubusercontent.com/8929706/228743745-bc8205f8-5a35-444a-9f48-bb6c01842eb5.png) | ![image](https://user-images.githubusercontent.com/8929706/228743754-3c80c1d6-86bc-464a-8129-488481ee3d04.png) |
