### PR TITLE
ルールページの記事作成日を表示しないよう変更

### DIFF
--- a/src/content/2.docs/1.rules/1.build.md
+++ b/src/content/2.docs/1.rules/1.build.md
@@ -1,6 +1,6 @@
 ---
 title: 建築についてのルール
-updated: 2023-03-01
+created: null
 tag:
   - Minecraft
 author:

--- a/src/content/2.docs/1.rules/index.md
+++ b/src/content/2.docs/1.rules/index.md
@@ -1,6 +1,6 @@
 ---
 title: ルール
-updated: 2023-03-01
+created: null
 tag:
   - ルール
 author:


### PR DESCRIPTION
ルールページには更新日表示のみで良いので、作成日に `null` を設定しています。
https://github.com/jaoafa/jaoweb4/pull/74#issuecomment-1491898961

ルールトップページ（ルールの一覧ページ）は、文章が入っているので更新日を非表示にする必要はないと思っています。（ `updated` に `null` を設定するのはしない）